### PR TITLE
Fix missing parameter error

### DIFF
--- a/Janrain/JRCapture/Classes/JRCapture.m
+++ b/Janrain/JRCapture/Classes/JRCapture.m
@@ -440,6 +440,8 @@ captureRegistrationFormName:(NSString *)captureRegistrationFormName
 
             @"client_id" : [JRCaptureData sharedCaptureData].clientId,
             @"locale" : [JRCaptureData sharedCaptureData].captureLocale,
+            @"flow" : [JRCaptureData sharedCaptureData].captureFlowName,
+            @"flow_version" : [JRCaptureData sharedCaptureData].downloadedFlowVersion
     };
 
     [JRConnectionManager jsonRequestToUrl:refreshUrl params:params completionHandler:^(id r, NSError *e)


### PR DESCRIPTION
The `JRCapture refreshAccessTokenForDelegate:context:` method was getting the following error response from the /oauth/refresh_access_token endpoint:

```
{
    "code": 100,
    "error": "missing_argument",
    "error_description": "missing arguments: flow, version",
    "request_id": "vf6ar4e7gjdwsprm",
    "stat": "error"
}
```
Adding the "flow" and "flow_version" parameters to the request fixed the issue.