### PR TITLE
Fix layout issues

### DIFF
--- a/Janrain/JRCapture/Classes/JRTraditionalSigninViewController.m
+++ b/Janrain/JRCapture/Classes/JRTraditionalSigninViewController.m
@@ -94,38 +94,51 @@ typedef enum
 
 - (void)loadView
 {
-    myTableView = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, 320, 170) style:UITableViewStyleGrouped];
+    myTableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
     myTableView.backgroundColor = [UIColor clearColor];
     myTableView.scrollEnabled   = NO;
 
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-
-    [button setFrame:CGRectMake(10, 2, 300, 40)];
-    [button setBackgroundImage:[UIImage imageNamed:@"button_janrain_280x40.png"]
-                      forState:UIControlStateNormal];
-
-    [button setTitle:NSLocalizedString(@"Sign In", nil) forState:UIControlStateNormal];
-    [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-    [button setTitleShadowColor:[UIColor grayColor] forState:UIControlStateNormal];
-
-    button.titleLabel.font = [UIFont boldSystemFontOfSize:20.0];
-
-    [button addTarget:self
-               action:@selector(signInButtonTouchUpInside:)
-     forControlEvents:UIControlEventTouchUpInside];
-
-    UIView *footerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 50)];
-    [footerView addSubview:button];
-
-    myTableView.tableFooterView = footerView;
+    myTableView.tableFooterView = [self createFooterView];
     myTableView.dataSource = self;
     myTableView.delegate = self;
 
     self.view = myTableView;
 
     [self.view setClipsToBounds:NO];
+}
 
-//    [self createLoadingView];
+-(UIView*)createFooterView
+{
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+    
+    [button setBackgroundImage:[UIImage imageNamed:@"button_janrain_280x40.png"]
+                      forState:UIControlStateNormal];
+    
+    [button setTitle:NSLocalizedString(@"Sign In", nil) forState:UIControlStateNormal];
+    [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    [button setTitleShadowColor:[UIColor grayColor] forState:UIControlStateNormal];
+    
+    button.titleLabel.font = [UIFont boldSystemFontOfSize:20.0];
+    
+    [button addTarget:self
+               action:@selector(signInButtonTouchUpInside:)
+     forControlEvents:UIControlEventTouchUpInside];
+    
+    UIView *footerView = [[UIView alloc] init];
+    [footerView addSubview:button];
+    
+    [button setTranslatesAutoresizingMaskIntoConstraints:NO];
+    NSDictionary* viewsDictionary = NSDictionaryOfVariableBindings(button);
+    [footerView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-10-[button]-10-|" options:0 metrics:nil views:viewsDictionary]];
+    [footerView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-2-[button(40)]-|" options:0 metrics:nil views:viewsDictionary]];
+    
+    CGFloat height = [footerView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height;
+    CGRect frame = footerView.frame;
+    
+    frame.size.height = height;
+    footerView.frame = frame;
+
+    return footerView;
 }
 
 - (void)viewDidLoad
@@ -188,7 +201,7 @@ typedef enum
     {
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:cellId];
 
-        textField = [[UITextField alloc] initWithFrame:CGRectMake(10, 7, 280, 26)];
+        textField = [[UITextField alloc] init];
 
         textField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
         textField.clearButtonMode = UITextFieldViewModeWhileEditing;
@@ -197,7 +210,7 @@ typedef enum
         textField.returnKeyType = UIReturnKeyDone;
         textField.delegate = self;
 
-        [cell.contentView addSubview:textField];
+        [self pinView:textField toSidesOfCell:cell withInsets:UIEdgeInsetsMake(7.0, 10.0, 7.0, 10.0)];
 
         if (indexPath.row == 0)
         {
@@ -221,6 +234,21 @@ typedef enum
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
 
     return cell;
+}
+
+- (void)pinView:(UIView*)subView toSidesOfCell:(UITableViewCell*)cell withInsets:(UIEdgeInsets)insets
+{
+    [subView setTranslatesAutoresizingMaskIntoConstraints:NO];
+    [cell.contentView addSubview:subView];
+    
+    NSDictionary *viewsDictionary = NSDictionaryOfVariableBindings(subView);
+    
+    NSString *horizontalFormat = [NSString stringWithFormat:@"H:|-%1f-[subView]-%1f-|", insets.left, insets.right];
+    [cell.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:horizontalFormat options:0 metrics:nil views:viewsDictionary]];
+    NSString *verticalFormat = [NSString stringWithFormat:@"V:|-%1f-[subView]-%1f-|", insets.top, insets.bottom];
+    [cell.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:verticalFormat options:0 metrics:nil views:viewsDictionary]];
+    
+    [cell.contentView setNeedsLayout];
 }
 
 

--- a/Janrain/JREngage/Classes/JRProvidersController.m
+++ b/Janrain/JREngage/Classes/JRProvidersController.m
@@ -355,44 +355,45 @@
 
 - (void)createTraditionalSignInLoadingView
 {
-    self.myTraditionalSignInLoadingView = [[UIView alloc] initWithFrame:self.view.frame];
-
+    self.myTraditionalSignInLoadingView = [[UIView alloc] init];
     [self.myTraditionalSignInLoadingView setBackgroundColor:[UIColor blackColor]];
+    [self.myTraditionalSignInLoadingView setTranslatesAutoresizingMaskIntoConstraints:NO];
 
-    UILabel *loadingLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 180, 320, 30)];
+    UILabel *loadingLabel = [[UILabel alloc] init];
 
     [loadingLabel setText:NSLocalizedString(@"Completing Sign-In...",nil)];
     [loadingLabel setFont:[UIFont systemFontOfSize:20.0]];
     [loadingLabel setTextAlignment:(int)JR_TEXT_ALIGN_CENTER];
     [loadingLabel setTextColor:[UIColor whiteColor]];
     [loadingLabel setBackgroundColor:[UIColor clearColor]];
-    [loadingLabel setAutoresizingMask:UIViewAutoresizingNone |
-            UIViewAutoresizingFlexibleTopMargin |
-            UIViewAutoresizingFlexibleBottomMargin |
-            UIViewAutoresizingFlexibleRightMargin |
-            UIViewAutoresizingFlexibleLeftMargin];
+    [loadingLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
 
     UIActivityIndicatorView *loadingSpinner =
             [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
-
-    [loadingSpinner setFrame:CGRectMake(142, self.view.frame.size.height / 2 - 16, 37, 37)];
-    [loadingLabel setAutoresizingMask:UIViewAutoresizingNone |
-            UIViewAutoresizingFlexibleTopMargin |
-            UIViewAutoresizingFlexibleBottomMargin |
-            UIViewAutoresizingFlexibleRightMargin |
-            UIViewAutoresizingFlexibleLeftMargin];
+    [loadingSpinner setTranslatesAutoresizingMaskIntoConstraints:NO];
 
     [loadingLabel setTag:LOADING_VIEW_LABEL_TAG];
     [loadingSpinner setTag:LOADING_VIEW_SPINNER_TAG];
 
     [myTraditionalSignInLoadingView addSubview:loadingLabel];
     [myTraditionalSignInLoadingView addSubview:loadingSpinner];
+    
+    NSDictionary *viewsDict = NSDictionaryOfVariableBindings(loadingLabel, loadingSpinner, myTraditionalSignInLoadingView);
+    NSString *verticalFormat = @"V:|-180-[loadingLabel(30)]-14-[loadingSpinner(37)]";
+    [myTraditionalSignInLoadingView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:verticalFormat options:0 metrics:nil views:viewsDict]];
+    [myTraditionalSignInLoadingView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[loadingLabel]|" options:0 metrics:nil views:viewsDict]];
+    [myTraditionalSignInLoadingView addConstraint:[NSLayoutConstraint constraintWithItem:loadingSpinner attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:37.0]];
+    [myTraditionalSignInLoadingView addConstraint:[NSLayoutConstraint constraintWithItem:myTraditionalSignInLoadingView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:loadingSpinner attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0.0]];
+    [myTraditionalSignInLoadingView setNeedsLayout];
 
     [myTraditionalSignInLoadingView setTag:LOADING_VIEW_TAG];
     [myTraditionalSignInLoadingView setHidden:YES];
     [myTraditionalSignInLoadingView setAlpha:0.0];
 
     [self.view addSubview:myTraditionalSignInLoadingView];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[myTraditionalSignInLoadingView]|" options:0 metrics:nil views:viewsDict]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[myTraditionalSignInLoadingView]|" options:0 metrics:nil views:viewsDict]];
+    [self.view setNeedsLayout];
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation

--- a/Janrain/JREngage/Resources/xibs/JRProvidersController.xib
+++ b/Janrain/JREngage/Resources/xibs/JRProvidersController.xib
@@ -1,371 +1,76 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
-	<data>
-		<int key="IBDocument.SystemTarget">1280</int>
-		<string key="IBDocument.SystemVersion">11D50b</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2177</string>
-		<string key="IBDocument.AppKitVersion">1138.32</string>
-		<string key="IBDocument.HIToolboxVersion">568.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">1173</string>
-		</object>
-		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<string>IBUITableView</string>
-			<string>IBUIActivityIndicatorView</string>
-			<string>IBUIView</string>
-			<string>IBUILabel</string>
-			<string>IBProxyObject</string>
-		</object>
-		<object class="NSArray" key="IBDocument.PluginDependencies">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<object class="IBProxyObject" id="372490531">
-				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBProxyObject" id="975951072">
-				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBUIView" id="965265500">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<object class="NSMutableArray" key="NSSubviews">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<object class="IBUIView" id="180964750">
-						<reference key="NSNextResponder" ref="965265500"/>
-						<int key="NSvFlags">274</int>
-						<string key="NSFrameSize">{320, 480}</string>
-						<reference key="NSSuperview" ref="965265500"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="843633790"/>
-						<object class="NSColor" key="IBUIBackgroundColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MSAxIDEAA</bytes>
-						</object>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-					</object>
-					<object class="IBUITableView" id="843633790">
-						<reference key="NSNextResponder" ref="965265500"/>
-						<int key="NSvFlags">274</int>
-						<string key="NSFrameSize">{320, 480}</string>
-						<reference key="NSSuperview" ref="965265500"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
-						<object class="NSColor" key="IBUIBackgroundColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MCAwAA</bytes>
-						</object>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<bool key="IBUIBouncesZoom">NO</bool>
-						<int key="IBUIStyle">1</int>
-						<int key="IBUISeparatorStyle">1</int>
-						<int key="IBUISectionIndexMinimumDisplayRowCount">0</int>
-						<bool key="IBUIShowsSelectionImmediatelyOnTouchBegin">YES</bool>
-						<float key="IBUIRowHeight">44</float>
-						<float key="IBUISectionHeaderHeight">10</float>
-						<float key="IBUISectionFooterHeight">10</float>
-					</object>
-					<object class="IBUIActivityIndicatorView" id="412182601">
-						<reference key="NSNextResponder" ref="965265500"/>
-						<int key="NSvFlags">-2147483347</int>
-						<string key="NSFrame">{{141, 226}, {37, 37}}</string>
-						<reference key="NSSuperview" ref="965265500"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<bool key="IBUIHidesWhenStopped">NO</bool>
-						<int key="IBUIStyle">0</int>
-					</object>
-					<object class="IBUILabel" id="485969603">
-						<reference key="NSNextResponder" ref="965265500"/>
-						<int key="NSvFlags">-2147483345</int>
-						<string key="NSFrame">{{0, 175}, {320, 21}}</string>
-						<reference key="NSSuperview" ref="965265500"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="412182601"/>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">Loading providers. Please wait...</string>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC40MDAwMDAwMDYgMC40MDAwMDAwMDYgMC40MDAwMDAwMDYAA</bytes>
-						</object>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">1</int>
-						<float key="IBUIMinimumFontSize">10</float>
-						<int key="IBUITextAlignment">1</int>
-						<object class="IBUIFontDescription" key="IBUIFontDescription">
-							<int key="type">1</int>
-							<double key="pointSize">17</double>
-						</object>
-						<object class="NSFont" key="IBUIFont">
-							<string key="NSName">Helvetica</string>
-							<double key="NSSize">17</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-				</object>
-				<string key="NSFrameSize">{320, 480}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="180964750"/>
-				<object class="NSColor" key="IBUIBackgroundColor">
-					<int key="NSColorSpace">3</int>
-					<bytes key="NSWhite">MQA</bytes>
-					<object class="NSColorSpace" key="NSCustomColorSpace">
-						<int key="NSID">2</int>
-					</object>
-				</object>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-		</object>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<object class="NSMutableArray" key="connectionRecords">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">myLoadingLabel</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="485969603"/>
-					</object>
-					<int key="connectionID">8</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">myActivitySpinner</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="412182601"/>
-					</object>
-					<int key="connectionID">9</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">myTableView</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="843633790"/>
-					</object>
-					<int key="connectionID">10</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">myBackgroundView</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="180964750"/>
-					</object>
-					<int key="connectionID">21</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">view</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="965265500"/>
-					</object>
-					<int key="connectionID">23</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">dataSource</string>
-						<reference key="source" ref="843633790"/>
-						<reference key="destination" ref="372490531"/>
-					</object>
-					<int key="connectionID">11</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="843633790"/>
-						<reference key="destination" ref="372490531"/>
-					</object>
-					<int key="connectionID">12</int>
-				</object>
-			</object>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<object class="NSArray" key="orderedObjects">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<object class="NSArray" key="object" id="0">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-						</object>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="372490531"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="975951072"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">22</int>
-						<reference key="object" ref="965265500"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="843633790"/>
-							<reference ref="180964750"/>
-							<reference ref="412182601"/>
-							<reference ref="485969603"/>
-						</object>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">4</int>
-						<reference key="object" ref="843633790"/>
-						<reference key="parent" ref="965265500"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">19</int>
-						<reference key="object" ref="180964750"/>
-						<reference key="parent" ref="965265500"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">6</int>
-						<reference key="object" ref="412182601"/>
-						<reference key="parent" ref="965265500"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">7</int>
-						<reference key="object" ref="485969603"/>
-						<reference key="parent" ref="965265500"/>
-					</object>
-				</object>
-			</object>
-			<object class="NSMutableDictionary" key="flattenedProperties">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="NSArray" key="dict.sortedKeys">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<string>-1.CustomClassName</string>
-					<string>-1.IBPluginDependency</string>
-					<string>-2.CustomClassName</string>
-					<string>-2.IBPluginDependency</string>
-					<string>19.IBPluginDependency</string>
-					<string>22.IBPluginDependency</string>
-					<string>4.IBPluginDependency</string>
-					<string>6.IBPluginDependency</string>
-					<string>7.IBPluginDependency</string>
-				</object>
-				<object class="NSArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<string>JRProvidersController</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>UIResponder</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				</object>
-			</object>
-			<object class="NSMutableDictionary" key="unlocalizedProperties">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<reference key="dict.sortedKeys" ref="0"/>
-				<reference key="dict.values" ref="0"/>
-			</object>
-			<nil key="activeLocalization"/>
-			<object class="NSMutableDictionary" key="localizations">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<reference key="dict.sortedKeys" ref="0"/>
-				<reference key="dict.values" ref="0"/>
-			</object>
-			<nil key="sourceID"/>
-			<int key="maxID">24</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="IBPartialClassDescription">
-					<string key="className">JRProvidersController</string>
-					<string key="superclassName">UIViewController</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>myActivitySpinner</string>
-							<string>myBackgroundView</string>
-							<string>myLoadingLabel</string>
-							<string>myTableView</string>
-						</object>
-						<object class="NSArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>UIActivityIndicatorView</string>
-							<string>UIView</string>
-							<string>UILabel</string>
-							<string>UITableView</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>myActivitySpinner</string>
-							<string>myBackgroundView</string>
-							<string>myLoadingLabel</string>
-							<string>myTableView</string>
-						</object>
-						<object class="NSArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBToOneOutletInfo">
-								<string key="name">myActivitySpinner</string>
-								<string key="candidateClassName">UIActivityIndicatorView</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">myBackgroundView</string>
-								<string key="candidateClassName">UIView</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">myLoadingLabel</string>
-								<string key="candidateClassName">UILabel</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">myTableView</string>
-								<string key="candidateClassName">UITableView</string>
-							</object>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/JRProvidersController.h</string>
-					</object>
-				</object>
-			</object>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
-			<real value="1280" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
-			<integer value="3000" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">1173</string>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6250" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="JRProvidersController">
+            <connections>
+                <outlet property="myActivitySpinner" destination="6" id="9"/>
+                <outlet property="myBackgroundView" destination="19" id="21"/>
+                <outlet property="myLoadingLabel" destination="7" id="8"/>
+                <outlet property="myTableView" destination="4" id="10"/>
+                <outlet property="view" destination="22" id="23"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="22">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="19">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                </view>
+                <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" bouncesZoom="NO" style="grouped" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="4">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="11"/>
+                        <outlet property="delegate" destination="-1" id="12"/>
+                    </connections>
+                </tableView>
+                <activityIndicatorView hidden="YES" opaque="NO" clearsContextBeforeDrawing="NO" userInteractionEnabled="NO" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="6">
+                    <rect key="frame" x="141" y="226" width="37" height="37"/>
+                </activityIndicatorView>
+                <label hidden="YES" opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" text="Loading providers. Please wait..." textAlignment="center" lineBreakMode="tailTruncation" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="7">
+                    <rect key="frame" x="0.0" y="175" width="600" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" red="0.40000000600000002" green="0.40000000600000002" blue="0.40000000600000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="19" firstAttribute="top" secondItem="22" secondAttribute="top" id="25"/>
+                <constraint firstAttribute="trailing" secondItem="4" secondAttribute="trailing" id="26"/>
+                <constraint firstItem="7" firstAttribute="leading" secondItem="22" secondAttribute="leading" id="27"/>
+                <constraint firstItem="4" firstAttribute="top" secondItem="19" secondAttribute="top" id="28"/>
+                <constraint firstItem="19" firstAttribute="trailing" secondItem="4" secondAttribute="trailing" id="29"/>
+                <constraint firstItem="19" firstAttribute="bottom" secondItem="4" secondAttribute="bottom" id="30"/>
+                <constraint firstAttribute="bottom" secondItem="19" secondAttribute="bottom" id="31"/>
+                <constraint firstItem="19" firstAttribute="leading" secondItem="7" secondAttribute="leading" id="33"/>
+                <constraint firstItem="19" firstAttribute="leading" secondItem="4" secondAttribute="leading" id="34"/>
+                <constraint firstItem="7" firstAttribute="top" secondItem="22" secondAttribute="top" constant="175" id="36"/>
+                <constraint firstItem="4" firstAttribute="trailing" secondItem="7" secondAttribute="trailing" id="37"/>
+                <constraint firstAttribute="centerX" secondItem="6" secondAttribute="centerX" id="2lA-qs-Ssk"/>
+                <constraint firstItem="6" firstAttribute="top" secondItem="7" secondAttribute="bottom" constant="30" id="y3p-4G-Kbn"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <variation key="default">
+                <mask key="constraints">
+                    <exclude reference="2lA-qs-Ssk"/>
+                    <exclude reference="y3p-4G-Kbn"/>
+                </mask>
+            </variation>
+            <variation key="widthClass=compact">
+                <mask key="constraints">
+                    <include reference="2lA-qs-Ssk"/>
+                    <include reference="y3p-4G-Kbn"/>
+                </mask>
+            </variation>
+            <point key="canvasLocation" x="415" y="347"/>
+        </view>
+    </objects>
+</document>

--- a/Samples/SimpleCaptureDemo/SimpleCaptureDemo/SimpleCaptureDemo-Info.plist
+++ b/Samples/SimpleCaptureDemo/SimpleCaptureDemo/SimpleCaptureDemo-Info.plist
@@ -39,6 +39,8 @@
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>MainStoryboard</string>
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
There are layout issues when running the SDK on iPhone 6 and iPhone 6+ screen sizes at native resolution. The sign in button on the traditional sign in view controller has a gap on the right side. The loading screen that is displayed when signing in is not correctly laid out either. This commit fixes these issues, but there are likely others.
![ios_simulator_screen_shot_dec_10__2014__2_45_17_pm](https://cloud.githubusercontent.com/assets/10146366/5384402/a60dd7da-807e-11e4-82ba-1b33eb5efe7e.png)
![ios_simulator_screen_shot_dec_10__2014__3_07_46_pm](https://cloud.githubusercontent.com/assets/10146366/5384451/16463cea-807f-11e4-9dcf-618e26cff840.png)


