### PR TITLE
Created CocoaPods podspec file for the Janrain JUMP for iOS library.

### DIFF
--- a/Janrain.podspec
+++ b/Janrain.podspec
@@ -1,0 +1,18 @@
+#
+# Janrain podspec
+#
+
+Pod::Spec.new do |s|
+  s.name          = "Janrain"
+  s.version       = "3.9.0"
+  s.summary       = "Janrain JUMP for iOS library"
+  s.homepage      = "https://github.com/janrain/jump.ios"
+  s.license       = { :type => 'BSD', :file => 'LICENSE' }
+  s.author        = "Janrain"
+  s.source        = { :git => "https://github.com/janrain/jump.ios.git", :tag => "v3.9.0" }
+  s.platform      = :ios, '5.0'
+  s.source_files  = "Janrain/**/*.{h,m}"
+  s.exclude_files = "Janrain/JRCapture/**/*"
+  s.resources     = ["Janrain/JREngage/Resources/**/*", "Janrain/JREngage/**/*.js"]
+  s.requires_arc  = true
+end


### PR DESCRIPTION
We are using Janrain here at Gannett in an iOS app, and would like to have a CocoaPods podspec file for Janrain. We have been using an internal podspec file for a while now, and would like to have this integrated into your master repo.