### PR TITLE
Bugfix/duplicate symbols

### DIFF
--- a/Janrain/JRCapture/Classes/JRCaptureApidInterface.h
+++ b/Janrain/JRCapture/Classes/JRCaptureApidInterface.h
@@ -38,7 +38,7 @@
 
 @protocol JRCaptureDelegate;
 
-NSString *const kJRTradAuthUrlPath;
+FOUNDATION_EXPORT NSString *const kJRTradAuthUrlPath;
 
 /**
  * @internal

--- a/Janrain/JRCapture/Classes/JRCaptureError.h
+++ b/Janrain/JRCapture/Classes/JRCaptureError.h
@@ -44,7 +44,7 @@
  * @{
  **/
 
-NSString *const kJRCaptureErrorDomain;
+FOUNDATION_EXPORT NSString *const kJRCaptureErrorDomain;
 #define GENERIC_ERROR_RANGE 1000
 #define LOCAL_APID_ERROR_RANGE 2000
 #define APID_ERROR_RANGE 3000


### PR DESCRIPTION
Adding FOUNDATION_EXPORT to String constants to remove compiler warnings about duplicate symbols.