### PR TITLE
Cocoapods with dynamicFramework with correct HeaderSearchPaths

### DIFF
--- a/Janrain.podspec
+++ b/Janrain.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
   s.resources     = ["Janrain/JREngage/Resources/**/*", "Janrain/JREngage/**/*.js"]
   s.requires_arc  = true
   s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/AppAuth/Source" }
-  #s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/AppAuth/Source/iOS" }
   s.dependency 'AppAuth'
  
 end

--- a/Janrain.podspec
+++ b/Janrain.podspec
@@ -15,4 +15,8 @@ Pod::Spec.new do |s|
   s.exclude_files = "Janrain/JRCapture/**/*"
   s.resources     = ["Janrain/JREngage/Resources/**/*", "Janrain/JREngage/**/*.js"]
   s.requires_arc  = true
+  s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/AppAuth/Source" }
+  #s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/AppAuth/Source/iOS" }
+  s.dependency 'AppAuth'
+ 
 end


### PR DESCRIPTION
When using CocoaPods 1.1.1 with "use_framework!" option to integrate Jainrain as a dynamic framework resulted in headers not found error. For further details refer to issue #33.

Changeset:
* HEADER_SEARCH_PATHS is set as /AppAuth/Source/* in the target xc config. 
* Added AppAuth as a dependency in podspec.